### PR TITLE
Allow HTTP/S traeffic in firewall rules

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,18 @@ class vision_traefik (
       require => File['/vision/data/traefik'],
     }
   }
+  
+  firewall { '100 allow HTTP traffic':
+    dport  => 80,
+    proto  => tcp,
+    action => accept,
+  }
+  
+  firewall { '100 allow HTTPS traffic':
+    dport  => 443,
+    proto  => tcp,
+    action => accept,
+  }
 
   contain ::vision_traefik::docker
 }


### PR DESCRIPTION
required when networking mode is set to host
docker does not add these rules, otherwise other docker containers running on the host cannot access this service externally