### PR TITLE
Refactor for Traefik v2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://travis-ci.org/vision-it/vision-traefik.svg)](https://travis-ci.org/vision-it/vision-traefik)
 
-**Note**: This module only works with Traefik v2+
-
 ## Usage
+
+**Note**: This module only works with Traefik v2
 
 Include in the *Puppetfile*:
 

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -5,7 +5,7 @@ class vision_traefik::docker (
   String $whitelist  = $::vision_traefik::whitelist,
   Array $environment = $::vision_traefik::environment,
 
-  ) {
+) {
 
   $compose = {
     'version' => '3.7',
@@ -37,16 +37,16 @@ class vision_traefik::docker (
         },
         'ports'           => [
           {
-            'target' => 80,
+            'target'    => 80,
             'published' => 80,
-            'protocol' => 'tcp',
-            'mode' => 'host',
+            'protocol'  => 'tcp',
+            'mode'      => 'host',
           },
           {
-            'target' => 443,
+            'target'    => 443,
             'published' => 443,
-            'protocol' => 'tcp',
-            'mode' => 'host',
+            'protocol'  => 'tcp',
+            'mode'      => 'host',
           },
         ],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class vision_traefik (
     require => File['/vision/data/traefik'],
   }
 
-  file { 'http redirect config':
+  file { 'redirect config':
     ensure  => present,
     path    => '/vision/data/traefik/dynamic/redirect.toml',
     content => template('vision_traefik/redirect.toml.erb'),

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10"
       ]

--- a/spec/acceptance/default_spec.rb
+++ b/spec/acceptance/default_spec.rb
@@ -28,8 +28,8 @@ describe 'vision_traefik' do
   describe file('/vision/data/traefik/dynamic/redirect.toml') do
       it { is_expected.to be_file }
       it { is_expected.to contain 'managed by Puppet' }
-      it { is_expected.to contain 'https-redirect' }
-      it { is_expected.to contain 'HostRegexp' }
+      it { is_expected.to contain 'www-redirect' }
+      it { is_expected.to contain 'Host' }
       it { is_expected.to contain 'http.middleware' }
   end
 
@@ -39,6 +39,7 @@ describe 'vision_traefik' do
     it { is_expected.to contain 'checkNewVersion = false' }
     it { is_expected.to contain 'docker' }
     it { is_expected.to contain 'entryPoints' }
+    it { is_expected.to contain 'redirections.entrypoint' }
     it { is_expected.to contain 'api' }
     it { is_expected.not_to contain 'certificates' }
     it { is_expected.not_to contain 'certFile' }

--- a/templates/redirect.toml.erb
+++ b/templates/redirect.toml.erb
@@ -12,15 +12,18 @@
 <% end -%>
 
 [http.routers]
-  [http.routers.https-redirect]
-  rule = "HostRegexp(`{any:.*}`)"
-  middlewares = ["https-redirect"]
-  service = "noop"
-  entryPoints = ["http"]
+  [http.routers.default-redirects]
+    rule = "Host(`vision.fraunhofer.de`) && Path(`/`)"
+    middlewares = ["www-redirect"]
+    service = "noop"
+    entryPoints = ["https", "http"]
+    [http.routers.default-redirects.tls]
 
 [http.middlewares]
-  [http.middlewares.https-redirect.redirectscheme]
-    scheme = "https"
+  [http.middlewares.www-redirect.redirectregex]
+    regex = "^https?://vision.fraunhofer.de"
+    replacement = "https://www.vision.fraunhofer.de/"
+    permanent = true
 
 [http.services]
   # noop service, the URL will be never called

--- a/templates/traefik.toml.erb
+++ b/templates/traefik.toml.erb
@@ -29,6 +29,11 @@
 [entryPoints]
   [entryPoints.http]
     address = ":80"
+    [entryPoints.http.http]
+      [entryPoints.http.http.redirections]
+        [entryPoints.http.http.redirections.entrypoint]
+          to = "https"
+          scheme = "https"
   [entryPoints.https]
     address = ":443"
   [entryPoints.traefik]


### PR DESCRIPTION
 - Simpler http-to-https Redirects. https://github.com/containous/traefik/releases/tag/v2.2.0
 - Add Redirect for www-prefix